### PR TITLE
Redirects to a non-existent route

### DIFF
--- a/app_server/controllers/locations.js
+++ b/app_server/controllers/locations.js
@@ -171,7 +171,7 @@ module.exports.doAddReview = function(req, res){
     json : postdata
   };
   if (!postdata.author || !postdata.rating || !postdata.reviewText) {
-    res.redirect('/location/' + locationid + '/reviews/new?err=val');
+    res.redirect('/location/' + locationid + '/review/new?err=val');
   } else {
     request(
       requestOptions,
@@ -179,7 +179,7 @@ module.exports.doAddReview = function(req, res){
         if (response.statusCode === 201) {
           res.redirect('/location/' + locationid);
         } else if (response.statusCode === 400 && body.name && body.name === "ValidationError" ) {
-          res.redirect('/location/' + locationid + '/reviews/new?err=val');
+          res.redirect('/location/' + locationid + '/review/new?err=val');
         } else {
           console.log(body);
           _showError(req, res, response.statusCode);


### PR DESCRIPTION
I was having some issues with the last part of Chapter 7, and this fix seemed to address them. I think the problem was an empty/incomplete form redirecting to a non-existent route. Routes of the form "/location/' + locationid + '/reviews/" belong to the api_server not the app_server. Please let me know what you think. Thank you,