### PR TITLE
Adding id for jQuery form validation

### DIFF
--- a/app_server/views/location-review-form.jade
+++ b/app_server/views/location-review-form.jade
@@ -5,7 +5,7 @@ block content
     .col-lg-12
       h1= pageHeader.title
   .row
-    .col-xs-12.col-md-6
+    .col-xs-12.col-md-6#addReview
       form.form-horizontal(action="", method="post", role="form")
         - if (error == "val")
           .alert.alert-danger(role="alert") All fields required, please try again


### PR DESCRIPTION
'validation.js' performs missing-field form validation and adds an warning message to the #addReview DOM element. There is no #addReview attribute in this template. Adding the #addReview attribute to the div containing the form.