### PR TITLE
Fixed bug in ratingupdate logic

### DIFF
--- a/app_api/controllers/reviews.js
+++ b/app_api/controllers/reviews.js
@@ -82,6 +82,8 @@ var doSetAverageRating = function(location) {
         console.log("Average rating updated to", ratingAverage);
       }
     });
+  }else{
+    location.rating = 0;
   }
 };
 


### PR DESCRIPTION
The doSetAverageRating will not update the rating of a location when the last review is deleted as the reviews has length 0.