### PR TITLE
Fixed bug in doSetAverageRating  function

### DIFF
--- a/app_api/controllers/reviews.js
+++ b/app_api/controllers/reviews.js
@@ -75,6 +75,9 @@ var doSetAverageRating = function(location) {
     }
     ratingAverage = parseInt(ratingTotal / reviewCount, 10);
     location.rating = ratingAverage;
+  }else{
+    location.rating = 0
+  }
     location.save(function(err) {
       if (err) {
         console.log(err);


### PR DESCRIPTION
The doSetAverageRating is unable to update the rating when the last review is deleted as the reviews has length 0 for which it skips the if clause which update the rating.